### PR TITLE
Update prowl.py

### DIFF
--- a/medusa/notifiers/prowl.py
+++ b/medusa/notifiers/prowl.py
@@ -95,7 +95,7 @@ class Notifier(object):
                     apis.append(api)
 
         # Grab the per-show-notification recipients
-        if show_obj is not None:
+        if show_obj is not None and ("series_id" in show_obj) :
             recipients = mydb.select(
                 'SELECT notify_list '
                 'FROM tv_shows '


### PR DESCRIPTION
Fix the following error that causes post processor to stop:

```

2021-07-11 11:10:25 ERROR    POSTPROCESSOR :: [db102f3] Exception generated: 'list' object has no attribute 'series_id'
Traceback (most recent call last):
  File "/app/medusa/medusa/schedulers/scheduler.py", line 78, in run
    self.action.run(self.force)
  File "/app/medusa/medusa/process_tv.py", line 207, in run
    process_results.process(force=force, **kwargs)
  File "/app/medusa/medusa/process_tv.py", line 355, in process
    ignore_subs=ignore_subs)
  File "/app/medusa/medusa/process_tv.py", line 627, in process_files
    self.process_media(path, self.video_files, force, is_priority, ignore_subs)
  File "/app/medusa/medusa/process_tv.py", line 849, in process_media
    self.result = processor.process()
  File "/app/medusa/medusa/post_processor.py", line 1298, in process
    notifiers.notify_download(ep_obj)
  File "/app/medusa/medusa/notifiers/__init__.py", line 103, in notify_download
    n.notify_download(ep_obj)
  File "/app/medusa/medusa/notifiers/prowl.py", line 48, in notify_download
    recipients = self._generate_recipients(show)
  File "/app/medusa/medusa/notifiers/prowl.py", line 107, in _generate_recipients
    [show_obj.series_id, show_obj.indexer]
AttributeError: 'list' object has no attribute 'series_id'
```

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
